### PR TITLE
scale mode is documented as optional

### DIFF
--- a/pyky040/pyky040.py
+++ b/pyky040/pyky040.py
@@ -54,10 +54,11 @@ class Encoder:
         else:
             self.counter_loop = False
 
-        self.min_counter = params['scale_min']
         self.counter = self.min_counter + 0
-        self.max_counter = params['scale_max']
-
+        if 'scale_min' in params:
+            self.min_counter = params['scale_min']
+        if 'scale_max' in params:
+            self.max_counter = params['scale_max']
         if 'step' in params:
             self.step = params['step']
         if 'inc_callback' in params:


### PR DESCRIPTION
Setup encoder without scale mode (only `inc_callback` and `dec_callback`). Documentation says all arguments are optional but without `scale_min/max` `setup()` fails.

    enc.setup(inc_callback=inc_volume, dec_callback=dec_volume)